### PR TITLE
Compile wrapper using UMD modules

### DIFF
--- a/wrapper/build.gradle
+++ b/wrapper/build.gradle
@@ -15,6 +15,10 @@ task javadocJar(type: Jar) {
     from javadoc
 }
 
+compileKotlin2Js {
+    kotlinOptions.moduleKind = "umd"
+}
+
 artifacts {
     archives javadocJar, sourcesJar
 }


### PR DESCRIPTION
This changes the generated JS for the wrapper library to use UMD modules, which should be more compatible than plain module output.